### PR TITLE
fixed login -> main issue

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,10 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "./globals.css";
 
 import { AuthProvider } from "@/contexts/auth-context";
-import { SidebarProvider } from "@/contexts/sidebar-context";
-import { Sidebar } from "@/components/layout/sidebar";
-import { BreadcrumbNav } from "@/components/layout/breadcrumb-nav";
-import { LayoutContent } from "@/components/layout/layout-content";
+import { ClientLayoutWrapper } from "@/components/layout/client-layout-wrapper";
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 
@@ -78,21 +75,11 @@ export default async function RootLayout({
 
   return (
     <html lang="en" className="scroll-smooth">
-      <body className={`antialiased font-sans ${initialUser ? 'bg-white' : ''}`} suppressHydrationWarning={true}>
+      <body className="antialiased font-sans" suppressHydrationWarning={true}>
         <AuthProvider initialUser={initialUser}>
-          {initialUser ? (
-            <SidebarProvider>
-              <div style={{ position: 'relative', minHeight: '100vh' }}>
-                <Sidebar />
-                <LayoutContent>
-                  <BreadcrumbNav />
-                  {children}
-                </LayoutContent>
-              </div>
-            </SidebarProvider>
-          ) : (
-            children
-          )}
+          <ClientLayoutWrapper>
+            {children}
+          </ClientLayoutWrapper>
         </AuthProvider>
       </body>
     </html>

--- a/frontend/src/components/layout/client-layout-wrapper.tsx
+++ b/frontend/src/components/layout/client-layout-wrapper.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import React from 'react'
+import { usePathname } from 'next/navigation'
+import { useAuth } from '@/contexts/auth-context'
+import { SidebarProvider } from '@/contexts/sidebar-context'
+import { Sidebar } from '@/components/layout/sidebar'
+import { BreadcrumbNav } from '@/components/layout/breadcrumb-nav'
+import { LayoutContent } from '@/components/layout/layout-content'
+
+interface ClientLayoutWrapperProps {
+  children: React.ReactNode
+}
+
+export function ClientLayoutWrapper({ children }: ClientLayoutWrapperProps) {
+  const { isAuthenticated } = useAuth()
+  const pathname = usePathname()
+
+  // Show sidebar layout only for dashboard routes when authenticated
+  const shouldShowSidebarLayout = isAuthenticated && pathname.startsWith('/dashboard')
+
+  if (shouldShowSidebarLayout) {
+    return (
+      <SidebarProvider>
+        <div style={{ position: 'relative', minHeight: '100vh', backgroundColor: 'white' }}>
+          <Sidebar />
+          <LayoutContent>
+            <BreadcrumbNav />
+            {children}
+          </LayoutContent>
+        </div>
+      </SidebarProvider>
+    )
+  }
+
+  // For all other routes (including "/" regardless of auth state), show just the children
+  return <>{children}</>
+}


### PR DESCRIPTION
This pull request refactors the main application layout to move sidebar and dashboard-related layout logic into a new client-side component. The goal is to conditionally render the sidebar and dashboard layout only for authenticated users on dashboard routes, simplifying the root layout and improving maintainability.

**Layout refactoring and conditional rendering:**

* Introduced a new `ClientLayoutWrapper` component in `frontend/src/components/layout/client-layout-wrapper.tsx` that handles conditional rendering of the sidebar, breadcrumb navigation, and layout content based on authentication state and route path. The sidebar layout is now only shown for authenticated users on `/dashboard` routes.
* Updated `frontend/src/app/layout.tsx` to replace the previous sidebar and layout logic with the new `ClientLayoutWrapper`, removing direct imports and usage of sidebar-related components from the root layout. [[1]](diffhunk://#diff-f3bfc5eb8ab49540cf25bb4422d423fac9a4e15f744eb2e2d3b2e1a1b03e441fL5-R5) [[2]](diffhunk://#diff-f3bfc5eb8ab49540cf25bb4422d423fac9a4e15f744eb2e2d3b2e1a1b03e441fL81-R82)

These changes make the layout logic more modular and ensure that the sidebar is only rendered when appropriate.