### PR TITLE
Fix patient video display issue

### DIFF
--- a/frontend/src/app/api/doctor/sessions/route.ts
+++ b/frontend/src/app/api/doctor/sessions/route.ts
@@ -15,7 +15,7 @@ export async function GET() {
 
     const { data: sessions, error } = await supabase
       .from('sessions')
-      .select('id, created_at, patient_id, doctor_id, status, due_date, treatment_id, ai_evaluation, exercise_sets, exercise_reps, exercise_weight')
+      .select('id, created_at, patient_id, doctor_id, status, due_date, treatment_id, ai_evaluation, exercise_sets, exercise_reps, exercise_weight, previdurl, postvidurl, patient_notes')
       .order('created_at', { ascending: false })
       .limit(200)
 


### PR DESCRIPTION
Include `previdurl` and `postvidurl` in the doctor sessions API query to ensure patient videos display correctly.

Previously, the API was not selecting `previdurl` and `postvidurl` from the sessions table, preventing the video player on the doctor's dashboard from accessing the necessary video URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-e6d2ef61-4db3-49a7-9dcf-374812a25eb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e6d2ef61-4db3-49a7-9dcf-374812a25eb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

