### PR TITLE
Process backend logs and patient notes

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -504,10 +504,17 @@ async def perform_two_stage_analysis(video_id: str):
         key_frames_dir.mkdir(exist_ok=True)
         action_logger.log_file_operation("CREATE_DIR", key_frames_dir, True)
         
-        # Extract key frames
+        # Load angle data
+        with open(angle_file, 'r') as f:
+            angle_data_raw = json.load(f)
+        
+        angle_data = angle_data_raw.get('angle_data', [])
+        
+        # Extract key frames with pose data
         action_logger.log_processing_step("KEY_FRAME_EXTRACTION", video_id, "started")
-        analysis_package = key_frame_extractor.extract_key_frames(
+        analysis_package = key_frame_extractor.create_analysis_package(
             str(video_path), 
+            angle_data,
             str(key_frames_dir)
         )
         action_logger.log_processing_step("KEY_FRAME_EXTRACTION", video_id, "completed")

--- a/frontend/src/app/dashboard/doctor/components/ExerciseReview/PatientContextPanel.tsx
+++ b/frontend/src/app/dashboard/doctor/components/ExerciseReview/PatientContextPanel.tsx
@@ -193,6 +193,16 @@ export function PatientContextPanel({ caze }: Props) {
             )}
           </div>
           
+          {/* Patient Notes Section */}
+          {caze.patientNotes && (
+            <div className="mt-4 pt-4 border-t border-gray-200">
+              <h4 className="text-sm font-semibold text-gray-900 mb-3">Patient Notes</h4>
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                <p className="text-sm text-blue-900 whitespace-pre-wrap">{caze.patientNotes}</p>
+              </div>
+            </div>
+          )}
+
           {/* Recommended Exercise Section */}
           <div className="mt-4 pt-4 border-t border-gray-200">
             <h4 className="text-sm font-semibold text-gray-900 mb-3">Recommended Exercise</h4>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -54,6 +54,7 @@ function createPatientCaseFromSession(s: any, treatmentsById: any): PatientCase 
       return acc;
     }, {} as Record<string, number>),
     painIndicators: aiAnalysis.painIndicators.map(p => `${p.location}: ${p.type} pain (${p.severity}/10)`),
+    patientNotes: s.patient_notes || undefined,
   };
 
   return pc;

--- a/frontend/src/types/medical.types.ts
+++ b/frontend/src/types/medical.types.ts
@@ -52,6 +52,7 @@ export interface PatientCase {
   movementMetrics?: MovementMetric[];
   rangeOfMotion?: Record<string, number>; // e.g., { shoulderElevation: 87 }
   painIndicators?: string[];
+  patientNotes?: string; // Patient's notes to the doctor
 }
 
 export interface PrescriptionParams {


### PR DESCRIPTION
Integrate pose data into two-stage analysis and display patient notes in the doctor dashboard to enable accurate biomechanical analysis and improve doctor workflow.

The two-stage analysis endpoint was calling a basic key frame extraction method instead of the one that integrates pose data, leading to "Unable to assess" errors in the analysis. Additionally, patient notes, though stored, were not being mapped to the `PatientCase` interface or displayed in the `PatientContextPanel`, preventing doctors from seeing crucial patient context.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8a1d8e2-d459-47cb-8078-f8c0b0eb67d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8a1d8e2-d459-47cb-8078-f8c0b0eb67d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

